### PR TITLE
UDP Batching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea

--- a/H3MP.csproj
+++ b/H3MP.csproj
@@ -72,10 +72,14 @@
     <Compile Include="src\scripts\TrackedObjectReference.cs" />
     <Compile Include="src\tracking\TrackedAutoMeater.cs" />
     <Compile Include="src\tracking\TrackedAutoMeaterData.cs" />
+    <Compile Include="src\tracking\TrackedBlister.cs" />
+    <Compile Include="src\tracking\TrackedBlisterData.cs" />
     <Compile Include="src\tracking\TrackedBreakableGlass.cs" />
     <Compile Include="src\tracking\TrackedBreakableGlassData.cs" />
     <Compile Include="src\tracking\TrackedEncryption.cs" />
     <Compile Include="src\tracking\TrackedEncryptionData.cs" />
+    <Compile Include="src\tracking\TrackedFloater.cs" />
+    <Compile Include="src\tracking\TrackedFloaterData.cs" />
     <Compile Include="src\tracking\TrackedGatlingGun.cs" />
     <Compile Include="src\tracking\TrackedGatlingGunData.cs" />
     <Compile Include="src\tracking\TrackedItem.cs" />
@@ -105,11 +109,10 @@
       <HintPath>packages\HarmonyX.2.10.1\lib\net35\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>H:\Software and scripts\AssemblyPublicizer\Publicize.v1.0.0\Release\Assembly-CSharp.dll</HintPath>
+      <HintPath>packages\H3VR.GameLibs.0.111.8\lib\net35\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\H3VR.GameLibs.0.111.5\lib\net35\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>packages\H3VR.GameLibs.0.111.8\lib\net35\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx, Version=5.4.21.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\BepInEx.BaseLib.5.4.21\lib\net35\BepInEx.dll</HintPath>
@@ -137,10 +140,10 @@
       <HintPath>packages\UnityEngine.5.6.1\lib\net35\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\H3VR.GameLibs.0.111.5\lib\net35\UnityEngine.UI.dll</HintPath>
+      <HintPath>packages\H3VR.GameLibs.0.111.8\lib\net35\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="Valve.Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\H3VR.GameLibs.0.111.5\lib\net35\Valve.Newtonsoft.Json.dll</HintPath>
+      <HintPath>packages\H3VR.GameLibs.0.111.8\lib\net35\Valve.Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/packages.config
+++ b/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="BepInEx.BaseLib" version="5.4.21" targetFramework="net35" />
   <package id="BepInEx.Core" version="5.4.21" targetFramework="net35" />
-  <package id="H3VR.GameLibs" version="0.111.5" targetFramework="net35" />
+  <package id="H3VR.GameLibs" version="0.111.8" targetFramework="net35" />
   <package id="HarmonyX" version="2.10.1" targetFramework="net35" />
   <package id="Mono.Cecil" version="0.10.4" targetFramework="net35" />
   <package id="MonoMod.RuntimeDetour" version="22.3.23.4" targetFramework="net35" />

--- a/src/GameManager.cs
+++ b/src/GameManager.cs
@@ -541,16 +541,10 @@ namespace H3MP
 
             PlayerManager player = players[ID];
 
-            Transform playerTransform = player.transform;
+            player.EnqueuePositionData(position, rotation, headPos, headRot, torsoPos, torsoRot, leftHandPos,
+                leftHandRot, rightHandPos, rightHandRot);
 
-            playerTransform.position = position;
-            playerTransform.rotation = rotation;
-            player.head.position = headPos;
-            player.head.rotation = headRot;
-            player.leftHand.position = leftHandPos;
-            player.leftHand.rotation = leftHandRot;
-            player.rightHand.position = rightHandPos;
-            player.rightHand.rotation = rightHandRot;
+
             float previousHealth = player.health;
             player.health = health;
             int previousMaxHealth = player.maxHealth;

--- a/src/Mod.cs
+++ b/src/Mod.cs
@@ -1454,7 +1454,7 @@ namespace H3MP
             //Server.IP = config["IP"].ToString();
             CreateManagerObject(true);
 
-            Server.Start((ushort)config["MaxClientCount"], (ushort)config["Port"]);
+            Server.Start((ushort)config["MaxClientCount"], (ushort)config["Port"], (int)config["TickRate"]);
 
             if (GameManager.scene.Equals("TakeAndHold_Lobby_2"))
             {

--- a/src/networking/Client.cs
+++ b/src/networking/Client.cs
@@ -54,7 +54,7 @@ namespace H3MP.Networking
         public static IAsyncResult connectResult;
         public static int punchThroughAttemptCounter;
 
-
+        public int tickRate = 20;
         public Timer tickTimer = new Timer();
         
         /// <summary>
@@ -99,6 +99,7 @@ namespace H3MP.Networking
 
         public void SetTickRate(int tickRate)
         {
+            this.tickRate = tickRate;
             tickTimer.Elapsed += Tick;
             tickTimer.Interval = 1000f / tickRate;
             tickTimer.AutoReset = true;

--- a/src/networking/Client.cs
+++ b/src/networking/Client.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
+using System.Timers;
 using UnityEngine;
 
 namespace H3MP.Networking
@@ -53,6 +54,9 @@ namespace H3MP.Networking
         public static IAsyncResult connectResult;
         public static int punchThroughAttemptCounter;
 
+
+        public Timer tickTimer = new Timer();
+        
         /// <summary>
         /// CUSTOMIZATION
         /// Delegate for the OnDisconnect event
@@ -93,6 +97,19 @@ namespace H3MP.Networking
             tcp.Connect();
         }
 
+        public void SetTickRate(int tickRate)
+        {
+            tickTimer.Elapsed += Tick;
+            tickTimer.Interval = 1000f / tickRate;
+            tickTimer.AutoReset = true;
+            tickTimer.Start();
+        }
+
+        private void Tick(object sender, ElapsedEventArgs e)
+        {
+            ClientSend.SendBatchedPackets();
+        }
+        
         public class TCP
         {
             public TcpClient socket;
@@ -374,7 +391,7 @@ namespace H3MP.Networking
                 }
             }
 
-            private void HandleData(byte[] data)
+            public void HandleData(byte[] data)
             {
                 using(Packet packet = new Packet(data))
                 {
@@ -637,6 +654,7 @@ namespace H3MP.Networking
                 ClientHandle.FloaterCoreDamage,
                 ClientHandle.FloaterBeginExploding,
                 ClientHandle.FloaterExplode,
+                ClientHandle.BatchedPackets
             };
 
             // All vanilla scenes can be synced by default
@@ -942,6 +960,9 @@ namespace H3MP.Networking
                 {
                     Mod.OnConnectClicked(null);
                 }
+
+                tickTimer.Stop();
+                tickTimer.Elapsed -= Tick;
             }
         }
 

--- a/src/networking/Client.cs
+++ b/src/networking/Client.cs
@@ -42,8 +42,8 @@ namespace H3MP.Networking
         public bool gotWelcome = false;
         public bool gotConnectSync = false;
         public int pingAttemptCounter = 0;
-        private delegate void PacketHandler(Packet packet);
-        private static PacketHandler[] packetHandlers;
+        public delegate void PacketHandler(Packet packet);
+        public static PacketHandler[] packetHandlers;
         public static Dictionary<string, int> synchronizedScenes;
         public static TrackedObjectData[] objects; // All tracked objects, regardless of whos control they are under
 
@@ -644,6 +644,7 @@ namespace H3MP.Networking
                 ClientHandle.SightFlipperState,
                 ClientHandle.SightRaiserState,
                 ClientHandle.GatlingGunFire,
+                null, // punch through
                 ClientHandle.GasCuboidGout,
                 ClientHandle.GasCuboidDamage,
                 ClientHandle.GasCuboidHandleDamage,

--- a/src/networking/ClientHandle.cs
+++ b/src/networking/ClientHandle.cs
@@ -4775,7 +4775,12 @@ namespace H3MP.Networking
             {
                 int length = packet.ReadInt();
                 byte[] data = packet.ReadBytes(length);
-                Client.singleton.udp.HandleData(data);
+
+                using (Packet childPacket = new Packet(data))
+                {
+                    int packetId = childPacket.ReadInt();
+                    Client.packetHandlers[packetId](childPacket);
+                }
             }
         }
     }

--- a/src/networking/ClientHandle.cs
+++ b/src/networking/ClientHandle.cs
@@ -17,6 +17,7 @@ namespace H3MP.Networking
         {
             string msg = packet.ReadString();
             int ID = packet.ReadInt();
+            Client.singleton.SetTickRate(packet.ReadByte());
             GameManager.colorByIFF = packet.ReadBool();
             GameManager.nameplateMode = packet.ReadInt();
             GameManager.radarMode = packet.ReadInt();
@@ -4765,6 +4766,16 @@ namespace H3MP.Networking
                 ++FloaterPatch.explodeSkip;
                 trackedFloaterData.physicalFloater.physicalFloater.Explode();
                 --FloaterPatch.explodeSkip;
+            }
+        }
+
+        public static void BatchedPackets(Packet packet)
+        {
+            while (packet.UnreadLength() > 0)
+            {
+                int length = packet.ReadInt();
+                byte[] data = packet.ReadBytes(length);
+                Client.singleton.udp.HandleData(data);
             }
         }
     }

--- a/src/networking/ClientSend.cs
+++ b/src/networking/ClientSend.cs
@@ -88,6 +88,7 @@ namespace H3MP.Networking
                 int curLength = batchedPacket.Length();
                 if (curLength > 0 && curLength + packetData.Length > mtu)
                 {
+                    batchedPacket.WriteLength();
                     Client.singleton.udp.SendData(batchedPacket);
                     batchedPacket.Dispose();
                     batchedPacket = new Packet((int)ClientPackets.batchedPacket);
@@ -100,6 +101,7 @@ namespace H3MP.Networking
             // Send the remaining data
             if (batchedPacket.Length() > 0)
             {
+                batchedPacket.WriteLength();
                 Client.singleton.udp.SendData(batchedPacket);
             }
             batchedPacket.Dispose();

--- a/src/networking/Packet.cs
+++ b/src/networking/Packet.cs
@@ -203,7 +203,8 @@ namespace H3MP.Networking
         floaterDamage = 190,
         floaterCoreDamage = 191,
         floaterBeginExploding = 192,
-        floaterExplode = 193
+        floaterExplode = 193,
+        batchedPacket = 194
     }
 
     /// <summary>Sent from client to server.</summary>
@@ -393,7 +394,8 @@ namespace H3MP.Networking
         floaterDamage = 181,
         floaterCoreDamage = 182,
         floaterBeginExploding = 183,
-        floaterExplode = 184
+        floaterExplode = 184,
+        batchedPacket = 185
     }
 
     public class Packet : IDisposable

--- a/src/networking/Server.cs
+++ b/src/networking/Server.cs
@@ -37,6 +37,7 @@ namespace H3MP.Networking
 
         public static List<ServerClient> PTClients = new List<ServerClient>();
 
+        public static int tickRate = 20;
         public static Timer tickTimer = new Timer();
         
         /// <summary>
@@ -75,6 +76,7 @@ namespace H3MP.Networking
                 GameManager.SyncTrackedObjects(true, true);
             }
 
+            Server.tickRate = tickRate;
             tickTimer.Elapsed += Tick;
             tickTimer.Interval = 1000f / tickRate;
             tickTimer.AutoReset = true;

--- a/src/networking/ServerClient.cs
+++ b/src/networking/ServerClient.cs
@@ -22,6 +22,8 @@ namespace H3MP.Networking
         public bool attemptingPunchThrough;
         public long ping;
 
+        public Dictionary<object, byte[]> queuedPackets = new Dictionary<object, byte[]>();
+        
         public IPEndPoint PTEndPoint;
         public bool punchThrough;
         public bool PTUDPEstablished;

--- a/src/networking/ServerHandle.cs
+++ b/src/networking/ServerHandle.cs
@@ -5307,8 +5307,14 @@ namespace H3MP.Networking
         {
             while (packet.UnreadLength() > 0)
             {
-                // I think this will work
-                Server.clients[clientID].udp.HandleData(packet);
+                int length = packet.ReadInt();
+                byte[] data = packet.ReadBytes(length);
+
+                using (Packet childPacket = new Packet(data))
+                {
+                    int packetId = childPacket.ReadInt();
+                    Server.packetHandlers[packetId](clientID, childPacket);
+                }
             }
         }
     }

--- a/src/networking/ServerHandle.cs
+++ b/src/networking/ServerHandle.cs
@@ -5302,5 +5302,14 @@ namespace H3MP.Networking
                 ServerSend.FloaterExplode(trackedID, clientID);
             }
         }
+
+        public static void BatchedPackets(int clientID, Packet packet)
+        {
+            while (packet.UnreadLength() > 0)
+            {
+                // I think this will work
+                Server.clients[clientID].udp.HandleData(packet);
+            }
+        }
     }
 }

--- a/src/networking/ServerSend.cs
+++ b/src/networking/ServerSend.cs
@@ -104,7 +104,7 @@ namespace H3MP.Networking
 
             const int mtu = 1300;
             
-            Packet batchedPacket = new Packet((int) ClientPackets.batchedPacket);
+            Packet batchedPacket = new Packet((int) ServerPackets.batchedPacket);
             
             foreach (var packetData in packetsToSend)
             {
@@ -113,9 +113,10 @@ namespace H3MP.Networking
                 int curLength = batchedPacket.Length();
                 if (curLength > 0 && curLength + packetData.Length > mtu)
                 {
+                    batchedPacket.WriteLength();
                     client.udp.SendData(batchedPacket);
                     batchedPacket.Dispose();
-                    batchedPacket = new Packet((int)ClientPackets.batchedPacket);
+                    batchedPacket = new Packet((int)ServerPackets.batchedPacket);
                 }
                 
                 // Then add the data to the batch
@@ -125,6 +126,7 @@ namespace H3MP.Networking
             // Send the remaining data
             if (batchedPacket.Length() > 0)
             {
+                batchedPacket.WriteLength();
                 client.udp.SendData(batchedPacket);
             }
             batchedPacket.Dispose();
@@ -481,7 +483,7 @@ namespace H3MP.Networking
                                 Mod.LogWarning("Update packet size for " + trackedObject.trackedID + " of type: " + trackedObject.typeIdentifier + " is above 1500 bytes");
                             }
 
-                            SendUDPDataToClients(packet, GameManager.playersPresent);
+                            SendUDPDataToClients(packet, GameManager.playersPresent, key:trackedObject);
                         }
                     }
                     else if (!trackedObject.latestUpdateSent)

--- a/src/networking/ServerSend.cs
+++ b/src/networking/ServerSend.cs
@@ -390,7 +390,7 @@ namespace H3MP.Networking
                         packet.Write((short)0);
                     }
 
-                    SendUDPData(otherPlayers, packet, ID);
+                    SendUDPData(otherPlayers, packet, ID, false, GM.CurrentPlayerBody);
                 }
             }
         }

--- a/src/networking/ServerSend.cs
+++ b/src/networking/ServerSend.cs
@@ -1,4 +1,4 @@
-﻿using FistVR;
+using FistVR;
 using H3MP.Tracking;
 using System;
 using System.Collections.Generic;
@@ -55,12 +55,17 @@ namespace H3MP.Networking
                 }
             }
         }
-
-        public static void SendUDPData(List<int> toClients, Packet packet, int exclude = -1, bool custom = false)
+        
+        public static void SendUDPData(List<int> toClients, Packet packet, int exclude = -1, bool custom = false, object key = null)
         {
             if (custom)
             {
                 ConvertToCustomID(packet);
+            }
+
+            if (key == null)
+            {
+                key = new object();
             }
 #if DEBUG
             if (Input.GetKey(KeyCode.PageDown))
@@ -73,11 +78,58 @@ namespace H3MP.Networking
             {
                 if (exclude == -1 || toClients[i] != exclude)
                 {
-                    Server.clients[toClients[i]].udp.SendData(packet);
+                    //Server.clients[toClients[i]].udp.SendData(packet);
+                    Server.clients[toClients[i]].queuedPackets[key] = packet.ToArray();
                 }
             }
         }
 
+        public static void SendAllBatchedUDPData()
+        {
+            foreach (var client in Server.clients.Values)
+            {
+                SendBatchedPackets(client);
+            }
+        }
+        
+        public static void SendBatchedPackets(ServerClient client)
+        {
+            
+            List<byte[]> packetsToSend = new List<byte[]>();
+            lock (client.queuedPackets)
+            {
+                packetsToSend.AddRange(client.queuedPackets.Values);
+                client.queuedPackets.Clear();
+            }
+
+            const int mtu = 1300;
+            
+            Packet batchedPacket = new Packet((int) ClientPackets.batchedPacket);
+            
+            foreach (var packetData in packetsToSend)
+            {
+
+                // If the data of this packet would put us over the MTU, send what we have now
+                int curLength = batchedPacket.Length();
+                if (curLength > 0 && curLength + packetData.Length > mtu)
+                {
+                    client.udp.SendData(batchedPacket);
+                    batchedPacket.Dispose();
+                    batchedPacket = new Packet((int)ClientPackets.batchedPacket);
+                }
+                
+                // Then add the data to the batch
+                batchedPacket.Write(packetData);
+            }
+
+            // Send the remaining data
+            if (batchedPacket.Length() > 0)
+            {
+                client.udp.SendData(batchedPacket);
+            }
+            batchedPacket.Dispose();
+        }
+        
         public static void SendTCPDataToAll(Packet packet, bool custom = false)
         {
             if (custom)
@@ -97,31 +149,37 @@ namespace H3MP.Networking
             }
         }
 
-        public static void SendUDPDataToAll(Packet packet, bool custom = false)
-        {
-            if (custom)
-            {
-                ConvertToCustomID(packet);
-            }
-#if DEBUG
-            if (Input.GetKey(KeyCode.PageDown))
-            {
-                Mod.LogInfo("SendUDPDataToAll: " + BitConverter.ToInt32(packet.ToArray(), 0));
-            }
-#endif
-            packet.WriteLength();
-            for(int i = 1; i<= Server.maxClientCount; ++i)
-            {
-                Server.clients[i].udp.SendData(packet);
-            }
-        }
+//         public static void SendUDPDataToAll(Packet packet, bool custom = false)
+//         {
+//             if (custom)
+//             {
+//                 ConvertToCustomID(packet);
+//             }
+// #if DEBUG
+//             if (Input.GetKey(KeyCode.PageDown))
+//             {
+//                 Mod.LogInfo("SendUDPDataToAll: " + BitConverter.ToInt32(packet.ToArray(), 0));
+//             }
+// #endif
+//             packet.WriteLength();
+//             for(int i = 1; i<= Server.maxClientCount; ++i)
+//             {
+//                 Server.clients[i].udp.SendData(packet);
+//             }
+//         }
 
-        public static void SendUDPDataToClients(Packet packet, List<int> clientIDs, int excluding = -1, bool custom = false)
+        public static void SendUDPDataToClients(Packet packet, List<int> clientIDs, int excluding = -1, bool custom = false, object key = null)
         {
             if (custom)
             {
                 ConvertToCustomID(packet);
             }
+
+            if (key == null)
+            {
+                key = new object();
+            }
+            
 #if DEBUG
             if (Input.GetKey(KeyCode.PageDown))
             {
@@ -133,7 +191,8 @@ namespace H3MP.Networking
             {
                 if (excluding == -1 || clientID != excluding)
                 {
-                    Server.clients[clientID].udp.SendData(packet);
+                    //Server.clients[clientID].udp.SendData(packet);
+                    Server.clients[clientID].queuedPackets[key] = packet.ToArray();
                 }
             }
         }
@@ -182,27 +241,27 @@ namespace H3MP.Networking
             }
         }
 
-        public static void SendUDPDataToAll(int exceptClient, Packet packet, bool custom = false)
-        {
-            if (custom)
-            {
-                ConvertToCustomID(packet);
-            }
-#if DEBUG
-            if (Input.GetKey(KeyCode.PageDown))
-            {
-                Mod.LogInfo("SendUDPDataToAll: " + BitConverter.ToInt32(packet.ToArray(), 0));
-            }
-#endif
-            packet.WriteLength();
-            for(int i = 1; i<= Server.maxClientCount; ++i)
-            {
-                if (i != exceptClient)
-                {
-                    Server.clients[i].udp.SendData(packet);
-                }
-            }
-        }
+//         public static void SendUDPDataToAll(int exceptClient, Packet packet, bool custom = false)
+//         {
+//             if (custom)
+//             {
+//                 ConvertToCustomID(packet);
+//             }
+// #if DEBUG
+//             if (Input.GetKey(KeyCode.PageDown))
+//             {
+//                 Mod.LogInfo("SendUDPDataToAll: " + BitConverter.ToInt32(packet.ToArray(), 0));
+//             }
+// #endif
+//             packet.WriteLength();
+//             for(int i = 1; i<= Server.maxClientCount; ++i)
+//             {
+//                 if (i != exceptClient)
+//                 {
+//                     Server.clients[i].udp.SendData(packet);
+//                 }
+//             }
+//         }
 
         public static void Welcome(int toClient, string msg, bool colorByIFF, int nameplateMode, int radarMode, bool radarColor, Dictionary<string, Dictionary<int, KeyValuePair<float, int>>> maxHealthEntries)
         {
@@ -210,6 +269,7 @@ namespace H3MP.Networking
             {
                 packet.Write(msg);
                 packet.Write(toClient);
+                packet.Write((byte)(int)Mod.config["TickRate"]);
                 packet.Write(colorByIFF);
                 packet.Write(nameplateMode);
                 packet.Write(radarMode);

--- a/src/scripts/PlayerManager.cs
+++ b/src/scripts/PlayerManager.cs
@@ -197,7 +197,7 @@ namespace H3MP.Scripts
             if (PositionData.Count < 2) return;
 
             int tickRate = ThreadManager.host ? Server.tickRate : Client.singleton.tickRate;
-            float multiplier = 0.5f + 0.25f * PositionData.Count;
+            float multiplier = Mathf.Clamp(0.5f + 0.25f * (PositionData.Count - 2), 0.5f, 2f);
             t += Time.unscaledDeltaTime * tickRate * multiplier;
             
             TemporalPositionData a = PositionData[0];


### PR DESCRIPTION
This pull request adds UDP batching to H3MP, which drastically reduces the packet overhead.
TL;DR is that it limits sending updates for player state and tracked objects to a configurable rate (we tested at 20hz and it ran well), and batches the updates into as few packets as possible. The only issue was that because the player bodies have no interpolation they looked pretty jittery. Nathan wrote some code to do interpolation, which has been tested (successfully so far).
The server side adds a single new parameter to the config - TickRate:
![image](https://github.com/TommySoucy/H3MP/assets/4451169/cdd088f7-5dad-40db-b52e-38416f760f94)

It doesn't matter if the client has it or not.  Currently, if this line is missing and hosting is attempted, it will error - we recommend a default of 20 in the distributed CFG file.