### PR TITLE
Hide self-PlayerBody when interacting with quickbelt

### DIFF
--- a/src/scripts/BodyWristMenuSection.cs
+++ b/src/scripts/BodyWristMenuSection.cs
@@ -17,6 +17,7 @@ namespace H3MP.Scripts
         public static Text colorText;
         public static Text visibilityText;
         public static Text handText;
+        public static Text selfHideText;
 
         public override void Enable()
         {
@@ -49,6 +50,7 @@ namespace H3MP.Scripts
             InitButton(new List<int>() { 0 }, new List<Vector3>() { new Vector3(-155, 100, 0) }, new Vector2(150, 150), new Vector2(45, 45), OnPreviousColorClicked, "<", out textOut);
             InitButton(new List<int>() { 0 }, new List<Vector3>() { new Vector3(0, 50, 0) }, new Vector2(1200, 150), new Vector2(270, 45), OnVisibleClicked, "Visible: " + (GameManager.currentPlayerBody != null && GameManager.currentPlayerBody.bodyRenderers != null && GameManager.currentPlayerBody.bodyRenderers.Length > 0 && GameManager.currentPlayerBody.bodyRenderers[0].enabled ? "True" : "False"), out visibilityText);
             InitButton(new List<int>() { 0 }, new List<Vector3>() { new Vector3(0, 0, 0) }, new Vector2(1200, 150), new Vector2(270, 45), OnHandsClicked, "Hands visible: " + (GameManager.currentPlayerBody != null && GameManager.currentPlayerBody.handRenderers != null && GameManager.currentPlayerBody.handRenderers.Length > 0 && GameManager.currentPlayerBody.handRenderers[0].enabled ? "True" : "False"), out handText);
+            InitButton(new List<int>() { 0 }, new List<Vector3>() { new Vector3(0, -50, 0) }, new Vector2(1200, 150), new Vector2(270, 45), OnSelfHideClicked, "Auto-hide self: " + (PlayerBody.optionAutoHideSelf ? "True" : "False"), out selfHideText);
             //InitButton(new List<int>() { 3 }, new List<Vector3>() { new Vector3(215, -140, 0) }, new Vector2(240, 240), new Vector2(70, 70), OnNextOptionsClicked, "Next", out textOut);
             //InitButton(new List<int>() { 4 }, new List<Vector3>() { new Vector3(-215, -140, 0) }, new Vector2(240, 240), new Vector2(70, 70), OnPrevOptionsClicked, "Prev", out textOut);
         }
@@ -240,6 +242,20 @@ namespace H3MP.Scripts
                 GameManager.handsVisible = !GameManager.handsVisible;
                 GameManager.currentPlayerBody.SetHandsVisible(GameManager.handsVisible);
                 handText.text = "Hands visible: " + GameManager.handsVisible;
+            }
+        }
+
+        private void OnSelfHideClicked(Text textRef)
+        {
+            if (GameManager.currentPlayerBody == null)
+            {
+                SM.PlayGlobalUISound(SM.GlobalUISound.Error, transform.position);
+            }
+            else
+            {
+                SM.PlayGlobalUISound(SM.GlobalUISound.Beep, transform.position);
+                GameManager.currentPlayerBody.ToggleSelfHide();
+                selfHideText.text = "Auto-hide self: " + (PlayerBody.optionAutoHideSelf ? "True" : "False");
             }
         }
 

--- a/src/scripts/PlayerBody.cs
+++ b/src/scripts/PlayerBody.cs
@@ -60,6 +60,8 @@ namespace H3MP.Scripts
         public Text usernameLabel;
         public Text healthLabel;
 
+
+
         public virtual void Awake()
         {
             GameManager.OnPlayerBodyInit += OnPlayerBodyInit;
@@ -343,6 +345,32 @@ namespace H3MP.Scripts
                         handTransforms[i].rotation = handsToFollow[i].rotation;
                     }
                 }
+                
+                // hide self when using quickbelt
+                var pitch = headToFollow.rotation.eulerAngles.x;
+                var hand0Pos = handsToFollow[0].position;
+                var hand1Pos = handsToFollow[1].position;
+
+                var handDist = 999f; // distance to nearest qb slot
+                foreach (var slot in GM.CurrentPlayerBody.QBSlots_Internal)
+                {
+                    var t = slot.transform;
+                    handDist = Mathf.Min(Vector3.Distance(hand0Pos, t.position), handDist);
+                    handDist = Mathf.Min(Vector3.Distance(hand1Pos, t.position), handDist);
+                }
+                
+                Debug.Log($"HMD Pitch: {pitch}\nHand dist: {handDist}");
+                
+                if (pitch > 54 && handDist <= 0.09f)
+                {
+                    Debug.Log("Hiding self!");
+                }
+                else if (pitch < 32 || (270 < pitch && pitch < 360))
+                {
+                    // begin timer to hide self
+                }
+                
+                Debug.Log("");
             }
         }
 

--- a/src/scripts/PlayerBody.cs
+++ b/src/scripts/PlayerBody.cs
@@ -64,7 +64,8 @@ namespace H3MP.Scripts
         // for self-hiding
         public static bool optionAutoHideSelf = true;
         private const float SELF_HIDE_PITCH = 54;
-        private const float SELF_UNHIDE_PITCH = 42;
+        private const float SELF_UNHIDE_PITCH = 50;
+        private const float SELF_UNHIDE_DELAY = 0.5f;
         private bool selfIsHidden = false;
         private bool selfIsUnhiding = false;
 
@@ -371,7 +372,6 @@ namespace H3MP.Scripts
                     {
                         if (pitch < SELF_UNHIDE_PITCH || (180 < pitch && pitch < 360))
                         {
-                            selfIsUnhiding = true;
                             AnvilManager.Run(SelfUnhideCoroutine());
                         }
                     }
@@ -414,13 +414,17 @@ namespace H3MP.Scripts
 
         private IEnumerator SelfUnhideCoroutine()
         {
-            yield return new WaitForSeconds(0.2f);
+            if (selfIsUnhiding) yield break;
+            selfIsUnhiding = true;
+
+            yield return new WaitForSeconds(SELF_UNHIDE_DELAY);
             if (!optionAutoHideSelf || !IsUsingQuickbelt())
             {
                 SetPOVBodyVisible(true);
                 SetPOVHandsVisible(true);
                 selfIsHidden = false;
             }
+
             selfIsUnhiding = false;
         }
 

--- a/src/scripts/PlayerBody.cs
+++ b/src/scripts/PlayerBody.cs
@@ -68,7 +68,7 @@ namespace H3MP.Scripts
         private const float SELF_UNHIDE_DELAY = 0.5f;
         private bool selfIsHidden = false;
         private bool selfIsUnhiding = false;
-
+        public FVRViveHand[] handScripts;
 
         public virtual void Awake()
         {
@@ -82,6 +82,11 @@ namespace H3MP.Scripts
                 handsToFollow = new Transform[2];
                 handsToFollow[0] = GM.CurrentPlayerBody.LeftHand;
                 handsToFollow[1] = GM.CurrentPlayerBody.RightHand;
+                handScripts = new FVRViveHand[2]
+                { 
+                    GM.CurrentPlayerBody.LeftHand.GetComponent<FVRViveHand>(), 
+                    GM.CurrentPlayerBody.RightHand.GetComponent<FVRViveHand>() 
+                };
                 if (headDisplayMode != HeadDisplayMode.Physical)
                 {
                     SetHeadVisible(false);
@@ -315,6 +320,11 @@ namespace H3MP.Scripts
                 handsToFollow = new Transform[2];
                 handsToFollow[0] = playerBody.LeftHand;
                 handsToFollow[1] = playerBody.RightHand;
+                handScripts = new FVRViveHand[2]
+                {
+                    GM.CurrentPlayerBody.LeftHand.GetComponent<FVRViveHand>(),
+                    GM.CurrentPlayerBody.RightHand.GetComponent<FVRViveHand>()
+                };
                 if (headDisplayMode != HeadDisplayMode.Physical)
                 {
                     SetHeadVisible(false);
@@ -396,16 +406,18 @@ namespace H3MP.Scripts
             float pitch = headToFollow.rotation.eulerAngles.x;
             if (SELF_HIDE_PITCH < pitch && pitch < 90)
             {
-                foreach (Transform t in handsToFollow)
+                for(int i=0; i < handScripts.Length; ++i)
                 {
-                    FVRViveHand hand = t.GetComponent<FVRViveHand>();
-                    if (hand == null) continue;
+                    if (handScripts[i] == null)
+                    {
+                        continue;
+                    }
 
-                    if (
-                        (hand.CurrentInteractable == null && (hand.CurrentHoveredQuickbeltSlotDirty != null) || hand.ClosestPossibleInteractable != null)
-                        || (hand.CurrentInteractable != null && hand.CurrentHoveredQuickbeltSlot != null)
-                    )
+                    if ((handScripts[i].CurrentInteractable == null && handScripts[i].CurrentHoveredQuickbeltSlotDirty != null || handScripts[i].ClosestPossibleInteractable != null)
+                        || (handScripts[i].CurrentInteractable != null && handScripts[i].CurrentHoveredQuickbeltSlot != null))
+                    {
                         return true;
+                    }
                 }
             }
 

--- a/src/scripts/PlayerBody.cs
+++ b/src/scripts/PlayerBody.cs
@@ -363,8 +363,8 @@ namespace H3MP.Scripts
                     {
                         if (usingQB)
                         {
-                            SetBodyVisible(false);
-                            SetHandsVisible(false);
+                            SetPOVBodyVisible(false);
+                            SetPOVHandsVisible(false);
                             selfIsHidden = true;
                         }
                     }
@@ -387,8 +387,8 @@ namespace H3MP.Scripts
             {
                 selfIsHidden = false;
                 selfIsUnhiding = false;
-                SetBodyVisible(GameManager.bodyVisible);
-                SetHandsVisible(GameManager.handsVisible);
+                SetPOVBodyVisible(true);
+                SetPOVHandsVisible(true);
             }
         }
 
@@ -417,11 +417,11 @@ namespace H3MP.Scripts
 
         private IEnumerator SelfUnhideCoroutine()
         {
-            yield return new WaitForSeconds(0.15f);
+            yield return new WaitForSeconds(0.2f);
             if (!optionAutoHideSelf || !IsUsingQuickbelt())
             {
-                SetBodyVisible(GameManager.bodyVisible);
-                SetHandsVisible(GameManager.handsVisible);
+                SetPOVBodyVisible(true);
+                SetPOVHandsVisible(true);
                 selfIsHidden = false;
             }
             selfIsUnhiding = false;
@@ -491,6 +491,34 @@ namespace H3MP.Scripts
                     if (handRenderers[i] != null)
                     {
                         handRenderers[i].enabled = visible;
+                    }
+                }
+            }
+        }
+
+        private void SetPOVBodyVisible(bool visible)
+        {
+            if (bodyRenderers != null)
+            {
+                for (int i = 0; i < bodyRenderers.Length; ++i)
+                {
+                    if (bodyRenderers[i] != null)
+                    {
+                        bodyRenderers[i].gameObject.layer = visible ? LayerMask.NameToLayer("Default") : LayerMask.NameToLayer("ExternalCamOnly");
+                    }
+                }
+            }
+        }
+
+        private void SetPOVHandsVisible(bool visible)
+        {
+            if (handRenderers != null)
+            {
+                for (int i = 0; i < handRenderers.Length; ++i)
+                {
+                    if (handRenderers[i] != null)
+                    {
+                        handRenderers[i].gameObject.layer = visible ? LayerMask.NameToLayer("Default") : LayerMask.NameToLayer("ExternalCamOnly");
                     }
                 }
             }

--- a/src/scripts/PlayerBody.cs
+++ b/src/scripts/PlayerBody.cs
@@ -353,12 +353,11 @@ namespace H3MP.Scripts
                     }
                 }
 
-                // Hide self when using quickbelt //
-                // TODO: better way to determine if this is the local PlayerBody?
-                if (headDisplayMode != HeadDisplayMode.Physical && optionAutoHideSelf)
+                // (Un)hide self when using quickbelt //    
+                if (GameManager.currentPlayerBody == this && optionAutoHideSelf)
                 {
-                    var usingQB = IsUsingQuickbelt();
-                    var pitch = headToFollow.rotation.eulerAngles.x;
+                    bool usingQB = IsUsingQuickbelt();
+                    float pitch = headToFollow.rotation.eulerAngles.x;
                     if (!selfIsHidden)
                     {
                         if (usingQB)
@@ -373,7 +372,7 @@ namespace H3MP.Scripts
                         if (pitch < SELF_UNHIDE_PITCH || (180 < pitch && pitch < 360))
                         {
                             selfIsUnhiding = true;
-                            StartCoroutine(nameof(SelfUnhideCoroutine));
+                            AnvilManager.Run(SelfUnhideCoroutine());
                         }
                     }
                 }
@@ -394,23 +393,21 @@ namespace H3MP.Scripts
 
         private bool IsUsingQuickbelt()
         {
-            try
+            float pitch = headToFollow.rotation.eulerAngles.x;
+            if (SELF_HIDE_PITCH < pitch && pitch < 90)
             {
-                var pitch = headToFollow.rotation.eulerAngles.x;
-                if (SELF_HIDE_PITCH < pitch && pitch < 90)
+                foreach (Transform t in handsToFollow)
                 {
-                    foreach (var t in handsToFollow)
-                    {
-                        var hand = t.GetComponent<FVRViveHand>();
-                        if (
-                            (hand.CurrentInteractable == null && (hand.CurrentHoveredQuickbeltSlotDirty != null) || hand.ClosestPossibleInteractable != null)
-                            || (hand.CurrentInteractable != null && hand.CurrentHoveredQuickbeltSlot != null)
-                        )
-                            return true;
-                    }
+                    FVRViveHand hand = t.GetComponent<FVRViveHand>();
+                    if (hand == null) continue;
+
+                    if (
+                        (hand.CurrentInteractable == null && (hand.CurrentHoveredQuickbeltSlotDirty != null) || hand.ClosestPossibleInteractable != null)
+                        || (hand.CurrentInteractable != null && hand.CurrentHoveredQuickbeltSlot != null)
+                    )
+                        return true;
                 }
             }
-            catch { /* no FVRViveHand = not local player */ }
 
             return false;
         }

--- a/src/tracking/TrackedPlayerBody.cs
+++ b/src/tracking/TrackedPlayerBody.cs
@@ -29,6 +29,11 @@ namespace H3MP.Tracking
                     physicalPlayerBody.headToFollow = GM.CurrentPlayerBody.Head;
                     physicalPlayerBody.handsToFollow[0] = GM.CurrentPlayerBody.LeftHand;
                     physicalPlayerBody.handsToFollow[1] = GM.CurrentPlayerBody.RightHand;
+                    physicalPlayerBody.handScripts = new FVRViveHand[2]
+                    {
+                        GM.CurrentPlayerBody.LeftHand.GetComponent<FVRViveHand>(),
+                        GM.CurrentPlayerBody.RightHand.GetComponent<FVRViveHand>()
+                    };
                     if (physicalPlayerBody.headDisplayMode != PlayerBody.HeadDisplayMode.Physical)
                     {
                         physicalPlayerBody.SetHeadVisible(false);
@@ -105,6 +110,11 @@ namespace H3MP.Tracking
                 }
                 physicalPlayerBody.handsToFollow[0] = playerBody.LeftHand;
                 physicalPlayerBody.handsToFollow[1] = playerBody.RightHand;
+                physicalPlayerBody.handScripts = new FVRViveHand[2]
+                {
+                    GM.CurrentPlayerBody.LeftHand.GetComponent<FVRViveHand>(),
+                    GM.CurrentPlayerBody.RightHand.GetComponent<FVRViveHand>()
+                };
                 if (physicalPlayerBody.headDisplayMode != PlayerBody.HeadDisplayMode.Physical)
                 {
                     physicalPlayerBody.SetHeadVisible(false);


### PR DESCRIPTION
If the player is using a body avatar, their avatar will hide upon interacting with their quickbelt while looking down. This allows them to more easily see their items without their avatar getting in the way.

I originally wanted to turn the avatar translucent, but the shaders used (Alloy) for the player bodies I've tested don't support transparency.