### PR TITLE
Fix unreachable codepath in Server.RegisterCustomPacketType

### DIFF
--- a/src/networking/Server.cs
+++ b/src/networking/Server.cs
@@ -582,8 +582,7 @@ namespace H3MP.Networking
 
         public static int RegisterCustomPacketType(string handlerID, int clientID = 0)
         {
-            int index = -1;
-
+            int index;
             if (Mod.registeredCustomPacketIDs.TryGetValue(handlerID, out index))
             {
                 Mod.LogWarning("Client " + clientID + " requested for " + handlerID + " custom packet handler to be registered but this ID already exists.");
@@ -591,14 +590,12 @@ namespace H3MP.Networking
             else // We don't yet have this handlerID, add it
             {
                 // Get next available handler ID
-                if(Mod.availableCustomPacketIndices.Count > 0)
+                if (Mod.availableCustomPacketIndices.Count > 0)
                 {
                     index = Mod.availableCustomPacketIndices[Mod.availableCustomPacketIndices.Count - 1];
                     Mod.availableCustomPacketIndices.RemoveAt(Mod.availableCustomPacketIndices.Count - 1);
                 }
-
-                // If couldn't find one, need to add more space to handlers array
-                if (index == -1)
+                else // If couldn't find one, need to add more space to handlers array
                 {
                     index = Mod.customPacketHandlers.Length;
                     Mod.CustomPacketHandler[] temp = Mod.customPacketHandlers;


### PR DESCRIPTION
When a server registers a new custom packet type, it first checks if `Mod.registeredCustomPacketIDs` already contains the specified handlerID by calling TryGetValue on it

Counterintuitively, [TryGetValue actually sets the out value to 0 if the key isn't found](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.trygetvalue?view=net-9.0#remarks), in this case being index

This means that when `Mod.availableCustomPacketIndices` is out, the if clause that should allocate more space for custom packets just never fires because it checks if `index == -1` causing custom packets handlers to pile up at index 0 like this

![image](https://github.com/user-attachments/assets/d9a8a34a-1720-463e-ab43-ca355fb122d7)

Seeing as the correct behaviour is to fire the clause when there's no space left, and the value of index gets written to anyways, just switching out the additional if clause to an else works fine.

![image](https://github.com/user-attachments/assets/d61080f8-3f05-4e88-b3f9-56411439ca14)
